### PR TITLE
UnitTestの変更

### DIFF
--- a/app/src/androidTest/java/com/example/gourmetsearcher/SearchRestaurantFlowTest.kt
+++ b/app/src/androidTest/java/com/example/gourmetsearcher/SearchRestaurantFlowTest.kt
@@ -23,7 +23,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
-/** レストラン検索のフローをテストする */
+/** レストラン検索のフローをテストするクラス */
 @RunWith(AndroidJUnit4::class)
 @LargeTest
 class SearchRestaurantFlowTest {

--- a/app/src/main/java/com/example/gourmetsearcher/repository/SearchLocationRepository.kt
+++ b/app/src/main/java/com/example/gourmetsearcher/repository/SearchLocationRepository.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 import kotlin.coroutines.resume
 
-/** 位置情報の取得のリポジトリ*/
+/** 位置情報の取得のリポジトリ */
 interface SearchLocationRepository {
     suspend fun getLocation(): Location?
 }
@@ -48,7 +48,8 @@ class SearchLocationRepositoryImpl
         private suspend fun fetchLocation(): Location? =
             suspendCancellableCoroutine { continuation ->
                 try {
-                    locationProvider.getCurrentLocation(Priority.PRIORITY_LOW_POWER, null)
+                    locationProvider
+                        .getCurrentLocation(Priority.PRIORITY_LOW_POWER, null)
                         .addOnCompleteListener { task ->
                             if (task.isSuccessful) {
                                 continuation.resume(task.result)

--- a/app/src/test/java/com/example/gourmetsearcher/repository/HotPepperRepositoryImplTest.kt
+++ b/app/src/test/java/com/example/gourmetsearcher/repository/HotPepperRepositoryImplTest.kt
@@ -18,12 +18,12 @@ import com.example.gourmetsearcher.source.HotPepperNetworkDataSource
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyDouble
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyString
-import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
@@ -40,7 +40,6 @@ class HotPepperRepositoryImplTest {
     @Mock
     private lateinit var mockCacheManager: CacheManager
 
-    @InjectMocks
     private lateinit var hotPepperRepository: HotPepperRepository
 
     private val mockSearchTerms = SearchTerms("keyword", CurrentLocation(35.0, 139.0), 1)
@@ -91,6 +90,12 @@ class HotPepperRepositoryImplTest {
                 )
             assertEquals(mockResponse, result)
         }
+
+    /** 各テスト前の準備 */
+    @Before
+    fun setup() {
+        hotPepperRepository = HotPepperRepositoryImpl(mockService, mockCacheManager)
+    }
 
     /** キャッシュミス時のテスト */
     @Test

--- a/app/src/test/java/com/example/gourmetsearcher/repository/HotPepperRepositoryImplTest.kt
+++ b/app/src/test/java/com/example/gourmetsearcher/repository/HotPepperRepositoryImplTest.kt
@@ -18,12 +18,12 @@ import com.example.gourmetsearcher.source.HotPepperNetworkDataSource
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyDouble
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyString
+import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
@@ -31,17 +31,19 @@ import org.mockito.Mockito.`when`
 import org.mockito.junit.MockitoJUnitRunner
 import retrofit2.Response
 
+/** HotPepperRepositoryImplのユニットテストクラス */
 @RunWith(MockitoJUnitRunner::class)
 class HotPepperRepositoryImplTest {
-    private lateinit var repository: HotPepperRepositoryImpl
-
     @Mock
     private lateinit var mockService: HotPepperNetworkDataSource
 
     @Mock
     private lateinit var mockCacheManager: CacheManager
 
-    private val searchTerms = SearchTerms("keyword", CurrentLocation(35.0, 139.0), 1)
+    @InjectMocks
+    private lateinit var hotPepperRepository: HotPepperRepository
+
+    private val mockSearchTerms = SearchTerms("keyword", CurrentLocation(35.0, 139.0), 1)
 
     private val mockResponse =
         Response.success(
@@ -68,36 +70,33 @@ class HotPepperRepositoryImplTest {
             ),
         )
 
-    @Before
-    fun setUp() {
-        repository = HotPepperRepositoryImpl(mockService, mockCacheManager)
-    }
-
-    /** キャッシュヒット時にキャッシュされたレスポンスを返すことを確認 */
+    /** キャッシュヒット時のテスト */
     @Test
-    fun testCacheHitReturnsCachedResponse() =
+    fun testExecuteCacheHit() =
         runBlocking {
-            `when`(mockCacheManager.get(searchTerms)).thenReturn(mockResponse)
+            `when`(mockCacheManager.get(mockSearchTerms)).thenReturn(mockResponse)
 
-            val result = repository.execute(searchTerms)
+            val result = hotPepperRepository.execute(mockSearchTerms)
 
-            verify(mockCacheManager).get(searchTerms)
-            verify(mockService, never()).getRestaurantDatum(
-                anyString(),
-                anyString(),
-                anyDouble(),
-                anyDouble(),
-                anyInt(),
-                anyString(),
-            )
+            verify(mockCacheManager).get(mockSearchTerms)
+
+            verify(mockService, never())
+                .getRestaurantDatum(
+                    anyString(),
+                    anyString(),
+                    anyDouble(),
+                    anyDouble(),
+                    anyInt(),
+                    anyString(),
+                )
             assertEquals(mockResponse, result)
         }
 
-    /** キャッシュミス時にAPIからレスポンスを取得し、キャッシュに保存することを確認 */
+    /** キャッシュミス時のテスト */
     @Test
-    fun testRetrieveRestaurantDetails() =
+    fun testExecuteCacheMiss() =
         runBlocking {
-            `when`(mockCacheManager.get(searchTerms)).thenReturn(null)
+            `when`(mockCacheManager.get(mockSearchTerms)).thenReturn(null)
             `when`(
                 mockService.getRestaurantDatum(
                     anyString(),
@@ -108,25 +107,27 @@ class HotPepperRepositoryImplTest {
                     anyString(),
                 ),
             ).thenReturn(mockResponse)
+            val result = hotPepperRepository.execute(mockSearchTerms)
 
-            val result = repository.execute(searchTerms)
+            verify(mockCacheManager).get(mockSearchTerms)
 
-            verify(mockCacheManager).get(searchTerms)
-            verify(mockService).getRestaurantDatum(
+            verify(
+                mockService,
+            ).getRestaurantDatum(
                 BuildConfig.API_KEY,
-                searchTerms.keyword,
-                searchTerms.location.lat,
-                searchTerms.location.lng,
-                searchTerms.range,
+                mockSearchTerms.keyword,
+                mockSearchTerms.location.lat,
+                mockSearchTerms.location.lng,
+                mockSearchTerms.range,
                 "json",
             )
-            verify(mockCacheManager).put(searchTerms, mockResponse)
+            verify(mockCacheManager).put(mockSearchTerms, mockResponse)
             assertEquals(mockResponse, result)
         }
 
-    /** APIからレスポンスを取得できなかった場合、nullを返すことを確認 */
+    /** API例外時のテスト */
     @Test
-    fun testGetRestaurantInfoWithException() =
+    fun testExecuteWithException() =
         runBlocking {
             `when`(
                 mockService.getRestaurantDatum(
@@ -138,9 +139,7 @@ class HotPepperRepositoryImplTest {
                     anyString(),
                 ),
             ).thenThrow(RuntimeException::class.java)
-
-            val result = repository.execute(searchTerms)
-
+            val result = hotPepperRepository.execute(mockSearchTerms)
             assertNull(result)
         }
 }

--- a/app/src/test/java/com/example/gourmetsearcher/repository/KeyWordHistoryRepositoryImplTest.kt
+++ b/app/src/test/java/com/example/gourmetsearcher/repository/KeyWordHistoryRepositoryImplTest.kt
@@ -2,9 +2,9 @@ package com.example.gourmetsearcher.repository
 
 import com.example.gourmetsearcher.manager.PreferencesManager
 import org.junit.Assert.assertEquals
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
@@ -16,8 +16,13 @@ class KeyWordHistoryRepositoryImplTest {
     @Mock
     private lateinit var preferences: PreferencesManager
 
-    @InjectMocks
     private lateinit var keyWordHistoryRepository: KeyWordHistoryRepository
+
+    /** 各テスト前の準備 */
+    @Before
+    fun setUp() {
+        keyWordHistoryRepository = KeyWordHistoryRepositoryImpl(preferences)
+    }
 
     /** saveHistoryItemが正しく呼び出されるかテスト */
     @Test

--- a/app/src/test/java/com/example/gourmetsearcher/repository/KeyWordHistoryRepositoryImplTest.kt
+++ b/app/src/test/java/com/example/gourmetsearcher/repository/KeyWordHistoryRepositoryImplTest.kt
@@ -10,35 +10,34 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.junit.MockitoJUnitRunner
 
+/** KeyWordHistoryRepositoryImplのユニットテストクラス */
 @RunWith(MockitoJUnitRunner::class)
 class KeyWordHistoryRepositoryImplTest {
     @Mock
     private lateinit var preferences: PreferencesManager
 
     @InjectMocks
-    private lateinit var keyWordHistoryRepository: KeyWordHistoryRepositoryImpl
+    private lateinit var keyWordHistoryRepository: KeyWordHistoryRepository
 
-    /** saveHistoryItemが呼ばれたときに、PreferencesManagerのsaveHistoryItemが呼ばれることを確認するテスト */
+    /** saveHistoryItemが正しく呼び出されるかテスト */
     @Test
-    fun testSaveHistoryItemWithNewEntry() {
+    fun testSaveHistoryItem() {
         val input = "keyword1"
         keyWordHistoryRepository.saveHistoryItem(input)
         verify(preferences).saveHistoryItem(input)
     }
 
-    /** getHistoryListが呼ばれたときに、PreferencesManagerのgetHistoryListが呼ばれ、期待されるリストが返されることを確認するテスト */
+    /** getHistoryListが期待通りのリストを返すかテスト */
     @Test
     fun testGetHistoryList() {
         val expectedHistoryList = listOf("keyword1", "keyword2", "keyword3")
         `when`(preferences.getHistoryList()).thenReturn(expectedHistoryList)
-
         val actualHistoryList = keyWordHistoryRepository.getHistoryList()
-
         assertEquals(expectedHistoryList, actualHistoryList)
         verify(preferences).getHistoryList()
     }
 
-    /** clearHistoryが呼ばれたときに、PreferencesManagerのclearHistoryが呼ばれることを確認するテスト */
+    /** clearHistoryが正しく呼び出されるかテスト */
     @Test
     fun testClearHistory() {
         keyWordHistoryRepository.clearHistory()

--- a/app/src/test/java/com/example/gourmetsearcher/repository/SearchLocationRepositoryImplTest.kt
+++ b/app/src/test/java/com/example/gourmetsearcher/repository/SearchLocationRepositoryImplTest.kt
@@ -1,0 +1,103 @@
+package com.example.gourmetsearcher.repository
+
+import android.location.Location
+import com.example.gourmetsearcher.model.data.CurrentLocation
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.Priority
+import com.google.android.gms.tasks.OnCompleteListener
+import com.google.android.gms.tasks.Task
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Answers
+import org.mockito.ArgumentMatchers.any
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.doAnswer
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.mockito.junit.MockitoJUnitRunner
+
+/** SearchLocationRepositoryImplのユニットテストクラス */
+@RunWith(MockitoJUnitRunner::class)
+class SearchLocationRepositoryImplTest {
+    @Mock(answer = Answers.RETURNS_DEFAULTS)
+    private lateinit var mockLocationProvider: FusedLocationProviderClient
+
+    @Mock(answer = Answers.RETURNS_DEFAULTS)
+    private lateinit var mockTask: Task<Location>
+
+    @InjectMocks
+    private lateinit var searchLocationRepository: SearchLocationRepository
+
+    /** 位置情報の取得が成功した場合のテスト */
+    @Test
+    fun testGetLocationSuccess() =
+        runTest {
+            val expectedLocation = CurrentLocation(35.6895, 139.6917)
+            val mockLocation = mock<Location>()
+            `when`(mockLocation.latitude).thenReturn(expectedLocation.lat)
+            `when`(mockLocation.longitude).thenReturn(expectedLocation.lng)
+            `when`(mockLocationProvider.getCurrentLocation(Priority.PRIORITY_LOW_POWER, null))
+                .thenReturn(mockTask)
+
+            doAnswer { invocation ->
+                val listener = invocation.getArgument(0) as OnCompleteListener<Location>
+                listener.onComplete(mockTask)
+                null
+            }.`when`(mockTask).addOnCompleteListener(any())
+
+            `when`(mockTask.isSuccessful).thenReturn(true)
+            `when`(mockTask.result).thenReturn(mockLocation)
+
+            val result = searchLocationRepository.getLocation()
+
+            assertNotNull(result)
+            val location =
+                result?.let {
+                    CurrentLocation(it.latitude, it.longitude)
+                }
+
+            assertEquals(expectedLocation, location)
+        }
+
+    /** 位置情報の取得が失敗した場合のテスト */
+    @Test
+    fun testGetLocationNullOnUnsuccessful() =
+        runBlocking {
+            `when`(mockLocationProvider.getCurrentLocation(Priority.PRIORITY_LOW_POWER, null))
+                .thenReturn(mockTask)
+
+            val result = searchLocationRepository.getLocation()
+
+            assertNull(result)
+        }
+
+    /** セキュリティ例外が発生した場合のテスト */
+    @Test
+    fun testGetLocationNullOnSecurityException() =
+        runBlocking {
+            `when`(mockLocationProvider.getCurrentLocation(Priority.PRIORITY_LOW_POWER, null))
+                .thenThrow(SecurityException())
+
+            val result = searchLocationRepository.getLocation()
+
+            assertNull(result)
+        }
+
+    /** ラインタイムアウト例外が発生した場合のテスト */
+    @Test
+    fun testGetLocationNullOnGenericException() =
+        runBlocking {
+            `when`(mockLocationProvider.getCurrentLocation(Priority.PRIORITY_LOW_POWER, null))
+                .thenThrow(RuntimeException())
+
+            val result = searchLocationRepository.getLocation()
+
+            assertNull(result)
+        }
+}

--- a/app/src/test/java/com/example/gourmetsearcher/repository/SearchLocationRepositoryImplTest.kt
+++ b/app/src/test/java/com/example/gourmetsearcher/repository/SearchLocationRepositoryImplTest.kt
@@ -11,11 +11,10 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Answers
 import org.mockito.ArgumentMatchers.any
-import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.doAnswer
 import org.mockito.Mockito.mock
@@ -25,14 +24,19 @@ import org.mockito.junit.MockitoJUnitRunner
 /** SearchLocationRepositoryImplのユニットテストクラス */
 @RunWith(MockitoJUnitRunner::class)
 class SearchLocationRepositoryImplTest {
-    @Mock(answer = Answers.RETURNS_DEFAULTS)
+    @Mock
     private lateinit var mockLocationProvider: FusedLocationProviderClient
 
-    @Mock(answer = Answers.RETURNS_DEFAULTS)
+    @Mock
     private lateinit var mockTask: Task<Location>
 
-    @InjectMocks
     private lateinit var searchLocationRepository: SearchLocationRepository
+
+    /** 各テスト前の準備 */
+    @Before
+    fun setUp() {
+        searchLocationRepository = SearchLocationRepositoryImpl(mockLocationProvider)
+    }
 
     /** 位置情報の取得が成功した場合のテスト */
     @Test

--- a/app/src/test/java/com/example/gourmetsearcher/usecase/keywordhistory/ClearKeyWordHistoryUseCaseTest.kt
+++ b/app/src/test/java/com/example/gourmetsearcher/usecase/keywordhistory/ClearKeyWordHistoryUseCaseTest.kt
@@ -1,0 +1,27 @@
+package com.example.gourmetsearcher.usecase.keywordhistory
+
+import com.example.gourmetsearcher.repository.KeyWordHistoryRepository
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.junit.MockitoJUnitRunner
+
+/** ClearKeyWordHistoryUseCaseのユニットテストクラス */
+@RunWith(MockitoJUnitRunner::class)
+class ClearKeyWordHistoryUseCaseTest {
+    @Mock
+    private lateinit var keyWordHistoryRepository: KeyWordHistoryRepository
+
+    @InjectMocks
+    private lateinit var clearKeyWordHistoryUseCase: ClearKeyWordHistoryUseCase
+
+    /** invokeが正しく呼び出されるかテスト */
+    @Test
+    fun testInvokeCallsClearHistory() {
+        clearKeyWordHistoryUseCase()
+
+        verify(keyWordHistoryRepository).clearHistory()
+    }
+}

--- a/app/src/test/java/com/example/gourmetsearcher/usecase/keywordhistory/GetKeyWordHistoryUseCaseTest.kt
+++ b/app/src/test/java/com/example/gourmetsearcher/usecase/keywordhistory/GetKeyWordHistoryUseCaseTest.kt
@@ -1,0 +1,31 @@
+package com.example.gourmetsearcher.usecase.keywordhistory
+
+import com.example.gourmetsearcher.repository.KeyWordHistoryRepository
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.junit.MockitoJUnitRunner
+
+/** GetKeyWordHistoryUseCaseのユニットテストクラス */
+@RunWith(MockitoJUnitRunner::class)
+class GetKeyWordHistoryUseCaseTest {
+    @Mock
+    private lateinit var keyWordHistoryRepository: KeyWordHistoryRepository
+
+    @InjectMocks
+    private lateinit var getKeyWordHistoryUseCase: GetKeyWordHistoryUseCase
+
+    /** invokeが履歴リストを返すかテスト */
+    @Test
+    fun testInvokeReturnsHistoryList() {
+        val expectedHistoryList = listOf("keyword1", "keyword2", "keyword3")
+        `when`(keyWordHistoryRepository.getHistoryList()).thenReturn(expectedHistoryList)
+
+        val result = getKeyWordHistoryUseCase()
+
+        assertEquals(expectedHistoryList, result)
+    }
+}

--- a/app/src/test/java/com/example/gourmetsearcher/usecase/keywordhistory/SaveKeyWordHistoryUseCaseTest.kt
+++ b/app/src/test/java/com/example/gourmetsearcher/usecase/keywordhistory/SaveKeyWordHistoryUseCaseTest.kt
@@ -1,0 +1,29 @@
+package com.example.gourmetsearcher.usecase.keywordhistory
+
+import com.example.gourmetsearcher.repository.KeyWordHistoryRepository
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.junit.MockitoJUnitRunner
+
+/** SaveKeyWordHistoryUseCaseのユニットテストクラス */
+@RunWith(MockitoJUnitRunner::class)
+class SaveKeyWordHistoryUseCaseTest {
+    @Mock
+    private lateinit var keyWordHistoryRepository: KeyWordHistoryRepository
+
+    @InjectMocks
+    private lateinit var saveKeyWordHistoryUseCase: SaveKeyWordHistoryUseCase
+
+    /** invokeが正しく呼び出されるかテスト */
+    @Test
+    fun testInvokeCallsSaveHistoryItem() {
+        val keyword = "testKeyword"
+
+        saveKeyWordHistoryUseCase(keyword)
+
+        verify(keyWordHistoryRepository).saveHistoryItem(keyword)
+    }
+}

--- a/app/src/test/java/com/example/gourmetsearcher/usecase/location/GetCurrentLocationUseCaseTest.kt
+++ b/app/src/test/java/com/example/gourmetsearcher/usecase/location/GetCurrentLocationUseCaseTest.kt
@@ -1,0 +1,54 @@
+package com.example.gourmetsearcher.usecase.location
+
+import android.location.Location
+import com.example.gourmetsearcher.model.data.CurrentLocation
+import com.example.gourmetsearcher.repository.SearchLocationRepository
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.mockito.junit.MockitoJUnitRunner
+
+/** GetCurrentLocationUseCaseのユニットテストクラス */
+@RunWith(MockitoJUnitRunner::class)
+class GetCurrentLocationUseCaseTest {
+    @Mock
+    private lateinit var searchLocationRepository: SearchLocationRepository
+
+    @InjectMocks
+    private lateinit var getCurrentLocationUseCase: GetCurrentLocationUseCase
+
+    /** 正しく位置情報が取得できることを確認するテスト */
+    @Test
+    fun testInvokeReturnsLocationSuccessful() =
+        runBlocking {
+            val expectedLocation = CurrentLocation(35.6895, 139.6917)
+            val mockLocation = mock<Location>()
+            `when`(mockLocation.latitude).thenReturn(expectedLocation.lat)
+            `when`(mockLocation.longitude).thenReturn(expectedLocation.lng)
+            `when`(searchLocationRepository.getLocation()).thenReturn(mockLocation)
+
+            val result =
+                getCurrentLocationUseCase()?.let {
+                    CurrentLocation(it.latitude, it.longitude)
+                }
+
+            assertEquals(expectedLocation, result)
+        }
+
+    /** 位置情報の取得に失敗した場合にnullが返却されることを確認するテスト */
+    @Test
+    fun testInvokeReturnsNull() =
+        runBlocking {
+            `when`(searchLocationRepository.getLocation()).thenReturn(null)
+
+            val result = getCurrentLocationUseCase()
+
+            assertNull(result)
+        }
+}

--- a/app/src/test/java/com/example/gourmetsearcher/usecase/network/GetHotPepperDataUseCaseTest.kt
+++ b/app/src/test/java/com/example/gourmetsearcher/usecase/network/GetHotPepperDataUseCaseTest.kt
@@ -1,0 +1,101 @@
+package com.example.gourmetsearcher.usecase.network
+
+import com.example.gourmetsearcher.model.api.BudgetData
+import com.example.gourmetsearcher.model.api.GenreData
+import com.example.gourmetsearcher.model.api.HotPepperResponse
+import com.example.gourmetsearcher.model.api.LargeAreaData
+import com.example.gourmetsearcher.model.api.PCData
+import com.example.gourmetsearcher.model.api.PhotoData
+import com.example.gourmetsearcher.model.api.Results
+import com.example.gourmetsearcher.model.api.Shops
+import com.example.gourmetsearcher.model.api.SmallAreaData
+import com.example.gourmetsearcher.model.api.Urls
+import com.example.gourmetsearcher.model.data.CurrentLocation
+import com.example.gourmetsearcher.model.data.SearchTerms
+import com.example.gourmetsearcher.repository.HotPepperRepository
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.junit.MockitoJUnitRunner
+import retrofit2.Response
+
+/** GetHotPepperDataUseCaseのユニットテストクラス */
+@RunWith(MockitoJUnitRunner::class)
+class GetHotPepperDataUseCaseTest {
+    @Mock
+    private lateinit var hotPepperRepository: HotPepperRepository
+
+    @InjectMocks
+    private lateinit var getHotPepperDataUseCase: GetHotPepperDataUseCase
+
+    private val mockResponse =
+        Response.success(
+            HotPepperResponse(
+                Results(
+                    listOf(
+                        Shops(
+                            "1",
+                            "Restaurant",
+                            "Address",
+                            "Station",
+                            LargeAreaData("Large Area"),
+                            SmallAreaData("Small Area"),
+                            GenreData("Genre"),
+                            BudgetData("Budget"),
+                            "Access",
+                            Urls("URL"),
+                            PhotoData(PCData("Photo URL")),
+                            "Open",
+                            "Close",
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+    private val mockSearchTerms = SearchTerms("", CurrentLocation(0.0, 0.0), 1)
+
+    /** 正しくAPIが呼び出された場合のテスト */
+    @Test
+    fun testInvokeReturnsSuccessful() =
+        runBlocking {
+            `when`(hotPepperRepository.execute(mockSearchTerms))
+                .thenReturn(mockResponse)
+
+            val result = getHotPepperDataUseCase(mockSearchTerms)
+
+            assertEquals(mockResponse, result)
+        }
+
+    /** レスポンスがnullの場合のテスト */
+    @Test
+    fun testInvokeReturnsNull() =
+        runBlocking {
+            `when`(hotPepperRepository.execute(mockSearchTerms))
+                .thenReturn(null)
+
+            val result = getHotPepperDataUseCase(mockSearchTerms)
+
+            assertNull(result)
+        }
+
+    /** APIエラー時のテスト */
+    @Test
+    fun testInvokeReturnsError() =
+        runBlocking {
+            `when`(hotPepperRepository.execute(mockSearchTerms))
+                .thenThrow(RuntimeException("API Error"))
+
+            try {
+                getHotPepperDataUseCase(mockSearchTerms)
+                assert(false)
+            } catch (e: RuntimeException) {
+                assert(e.message == "API Error")
+            }
+        }
+}

--- a/app/src/test/java/com/example/gourmetsearcher/viewmodel/InputKeyWordViewModelTest.kt
+++ b/app/src/test/java/com/example/gourmetsearcher/viewmodel/InputKeyWordViewModelTest.kt
@@ -1,25 +1,21 @@
 package com.example.gourmetsearcher.viewmodel
 
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.example.gourmetsearcher.usecase.keywordhistory.ClearKeyWordHistoryUseCase
 import com.example.gourmetsearcher.usecase.keywordhistory.GetKeyWordHistoryUseCase
 import com.example.gourmetsearcher.usecase.keywordhistory.SaveKeyWordHistoryUseCase
 import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.junit.MockitoJUnitRunner
 
+/** InputKeyWordViewModelのユニットテストクラス */
 @RunWith(MockitoJUnitRunner::class)
 class InputKeyWordViewModelTest {
-    @get:Rule
-    var instantTaskExecutorRule = InstantTaskExecutorRule()
-
     @Mock
     private lateinit var getHistoryListUseCase: GetKeyWordHistoryUseCase
 
@@ -29,19 +25,37 @@ class InputKeyWordViewModelTest {
     @Mock
     private lateinit var clearHistoryUseCase: ClearKeyWordHistoryUseCase
 
+    @InjectMocks
     private lateinit var viewModel: InputKeyWordViewModel
 
-    @Before
-    fun setUp() {
-        viewModel =
-            InputKeyWordViewModel(
-                getHistoryListUseCase,
-                saveHistoryItemUseCase,
-                clearHistoryUseCase,
-            )
+    /** 初期化時に履歴リストが正しく読み込まれることを確認するテスト */
+    @Test
+    fun testLoadHistoryOnInit() {
+        val initialHistory = listOf("item1", "item2")
+        `when`(getHistoryListUseCase()).thenReturn(initialHistory)
+
+        viewModel = InputKeyWordViewModel(getHistoryListUseCase, saveHistoryItemUseCase, clearHistoryUseCase)
+
+        assertEquals(initialHistory, viewModel.historyListData.value)
     }
 
-    /** 履歴リストの保存と取得を確認する */
+    /** 新しい項目を保存した後、履歴リストが更新されることを確認するテスト */
+    @Test
+    fun testSaveHistoryItemUpdatesHistoryList() {
+        val initialHistory = listOf("item1")
+        val newItem = "item2"
+        val updatedHistory = listOf("item2", "item1")
+
+        `when`(getHistoryListUseCase()).thenReturn(initialHistory, updatedHistory)
+
+        viewModel = InputKeyWordViewModel(getHistoryListUseCase, saveHistoryItemUseCase, clearHistoryUseCase)
+        viewModel.saveHistoryItem(newItem)
+
+        verify(saveHistoryItemUseCase).invoke(newItem)
+        assertEquals(updatedHistory, viewModel.historyListData.value)
+    }
+
+    /** 履歴リストの保存と取得を確認するテスト */
     @Test
     fun testSaveAndGetHistoryItem() {
         val keyword = "test"
@@ -53,7 +67,7 @@ class InputKeyWordViewModelTest {
         assertEquals(listOf(keyword), viewModel.historyListData.value)
     }
 
-    /** 履歴リストのクリアを確認する */
+    /** 履歴リストのクリアを確認するテスト */
     @Test
     fun testClearHistory() {
         viewModel.clearHistory()

--- a/app/src/test/java/com/example/gourmetsearcher/viewmodel/InputKeyWordViewModelTest.kt
+++ b/app/src/test/java/com/example/gourmetsearcher/viewmodel/InputKeyWordViewModelTest.kt
@@ -28,10 +28,11 @@ class InputKeyWordViewModelTest {
     @InjectMocks
     private lateinit var viewModel: InputKeyWordViewModel
 
+    private val initialHistory = listOf("apple", "banana")
+
     /** 初期化時に履歴リストが正しく読み込まれることを確認するテスト */
     @Test
     fun testLoadHistoryOnInit() {
-        val initialHistory = listOf("item1", "item2")
         `when`(getHistoryListUseCase()).thenReturn(initialHistory)
 
         viewModel = InputKeyWordViewModel(getHistoryListUseCase, saveHistoryItemUseCase, clearHistoryUseCase)
@@ -42,9 +43,8 @@ class InputKeyWordViewModelTest {
     /** 新しい項目を保存した後、履歴リストが更新されることを確認するテスト */
     @Test
     fun testSaveHistoryItemUpdatesHistoryList() {
-        val initialHistory = listOf("item1")
-        val newItem = "item2"
-        val updatedHistory = listOf("item2", "item1")
+        val newItem = "cherry"
+        val updatedHistory = listOf("apple", "banana", "cherry")
 
         `when`(getHistoryListUseCase()).thenReturn(initialHistory, updatedHistory)
 

--- a/app/src/test/java/com/example/gourmetsearcher/viewmodel/RestaurantDetailViewModelTest.kt
+++ b/app/src/test/java/com/example/gourmetsearcher/viewmodel/RestaurantDetailViewModelTest.kt
@@ -1,20 +1,21 @@
 package com.example.gourmetsearcher.viewmodel
 
 import org.junit.Assert.assertEquals
-import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.InjectMocks
+import org.mockito.junit.MockitoJUnitRunner
 import java.net.URLEncoder
 
+/** RestaurantDetailViewModelのユニットテストクラス */
+@RunWith(MockitoJUnitRunner::class)
 class RestaurantDetailViewModelTest {
+    @InjectMocks
     private lateinit var viewModel: RestaurantDetailViewModel
 
-    @Before
-    fun setUp() {
-        viewModel = RestaurantDetailViewModel()
-    }
-
+    /** 地図を開く機能のテスト */
     @Test
-    fun `openMap should encode the address and update searchAddress StateFlow`() {
+    fun testOpenMap() {
         val address = "東京都渋谷区道玄坂1-2-3"
         val encodedAddress = URLEncoder.encode(address, "UTF-8")
 
@@ -23,15 +24,17 @@ class RestaurantDetailViewModelTest {
         assertEquals(encodedAddress, viewModel.searchAddress.value)
     }
 
+    /** 住所をクリアする機能のテスト */
     @Test
-    fun `clearAddress should update searchAddress StateFlow to null`() {
+    fun testClearAddress() {
         viewModel.clearAddress()
 
         assertEquals(null, viewModel.searchAddress.value)
     }
 
+    /** URLを開く機能のテスト */
     @Test
-    fun `openUrl should update url StateFlow with the provided URL`() {
+    fun testOpenUrl() {
         val url = "https://example.com"
 
         viewModel.openUrl(url)
@@ -39,8 +42,9 @@ class RestaurantDetailViewModelTest {
         assertEquals(url, viewModel.url.value)
     }
 
+    /** URLをクリアする機能のテスト */
     @Test
-    fun `clearUrl should update url StateFlow to null`() {
+    fun testClearUrl() {
         viewModel.clearUrl()
 
         assertEquals(null, viewModel.url.value)

--- a/app/src/test/java/com/example/gourmetsearcher/viewmodel/RestaurantListViewModelTest.kt
+++ b/app/src/test/java/com/example/gourmetsearcher/viewmodel/RestaurantListViewModelTest.kt
@@ -140,14 +140,4 @@ class RestaurantListViewModelTest {
 
             verify(getHotPepperDataUseCase, times(2)).invoke(mockSearchTerms)
         }
-
-    /** 空のキーワードでの検索リトライテスト */
-    @Test
-    fun testRetrySearchWithEmptyKeyword() =
-        runTest {
-            viewModel.searchRestaurants(mockSearchTerms)
-            viewModel.retrySearch()
-
-            verify(getHotPepperDataUseCase, times(1)).invoke(mockSearchTerms)
-        }
 }

--- a/app/src/test/java/com/example/gourmetsearcher/viewmodel/SearchLocationViewModelTest.kt
+++ b/app/src/test/java/com/example/gourmetsearcher/viewmodel/SearchLocationViewModelTest.kt
@@ -46,29 +46,18 @@ class SearchLocationViewModelTest {
         Dispatchers.resetMain()
     }
 
-    /** 位置情報の取得時にエラーが発生した場合のテスト */
-    @Test
-    fun testGetLocationError() =
-        runTest {
-            `when`(getCurrentLocationUseCase()).thenThrow(RuntimeException())
-
-            viewModel.getLocation()
-
-            assertEquals(LocationSearchState.ERROR, viewModel.searchState.value)
-        }
-
     /** 位置情報の取得が成功した場合のテスト */
     @Test
-    fun testPerformSearch() =
+    fun testGetLocationSuccess() =
         runTest {
+            val expectedLocation = CurrentLocation(34.7010289, 135.4955003)
             val mockLocation = mock<Location>()
-            `when`(mockLocation.latitude).thenReturn(35.0)
-            `when`(mockLocation.longitude).thenReturn(135.0)
+            `when`(mockLocation.latitude).thenReturn(expectedLocation.lat)
+            `when`(mockLocation.longitude).thenReturn(expectedLocation.lng)
             `when`(getCurrentLocationUseCase()).thenReturn(mockLocation)
 
             viewModel.getLocation()
 
-            val expectedLocation = CurrentLocation(35.0, 135.0)
             assertEquals(expectedLocation, viewModel.locationData.value)
         }
 
@@ -79,29 +68,22 @@ class SearchLocationViewModelTest {
         assertEquals(LocationSearchState.ERROR, viewModel.searchState.value)
     }
 
-    /** 位置情報の取得に成功した場合のテスト */
+    /** ランタイムエラーが発生した場合のテスト */
     @Test
-    fun testGetLocationSuccess() =
+    fun testGetLocationError() =
         runTest {
-            val location = CurrentLocation(34.7010289, 135.4955003)
-            val mockLocation = mock(Location::class.java)
-            `when`(mockLocation.latitude).thenReturn(location.lat)
-            `when`(mockLocation.longitude).thenReturn(location.lng)
-            `when`(getCurrentLocationUseCase()).thenReturn(mockLocation)
-
-            val latch = CountDownLatch(1)
+            `when`(getCurrentLocationUseCase()).thenThrow(RuntimeException())
 
             viewModel.getLocation()
 
-            latch.await(1, TimeUnit.SECONDS)
-            assertEquals(location, viewModel.locationData.value)
+            assertEquals(LocationSearchState.ERROR, viewModel.searchState.value)
         }
 
-    /** セキュリティ例外が発生した場合のテスト */
+    /** nullポインタ例外が発生した場合のテスト */
     @Test
-    fun testGetLocationSecurityException() =
+    fun testGetLocationNullPointerException() =
         runBlocking {
-            `when`(getCurrentLocationUseCase()).thenThrow(SecurityException())
+            `when`(getCurrentLocationUseCase()).thenThrow(NullPointerException())
 
             val latch = CountDownLatch(1)
 
@@ -111,11 +93,11 @@ class SearchLocationViewModelTest {
             assertEquals(LocationSearchState.ERROR, viewModel.searchState.value)
         }
 
-    /** nullポインタ例外が発生した場合のテスト */
+    /** セキュリティ例外が発生した場合のテスト */
     @Test
-    fun testGetLocationNullPointerException() =
+    fun testGetLocationSecurityException() =
         runBlocking {
-            `when`(getCurrentLocationUseCase()).thenThrow(NullPointerException())
+            `when`(getCurrentLocationUseCase()).thenThrow(SecurityException())
 
             val latch = CountDownLatch(1)
 


### PR DESCRIPTION
## Issue
- #ISSUE_NUMBER

## 概要 (必須)
<!-- 概要をここに記入してください。 -->
- UnitTestのコメントの適切化
- 関数の命名規則をすべてtestからはじめるキャメルケースに統一
- UseCaseのUnitTestがなかったため、追加した
- [SearchLocationRepository.kt](https://github.com/0v0d/GourmetSearcher/commit/2977f0d01cbc22602a7e96681c2623e55202eae7#diff-d38386d154ab4c71f148428b67b0cb2b405b173a67b17e29959494a45519ca85)のhandleCompletionを削除

## 参考リンク (任意)
<!-- 参考文献などがあればここに記入してください。 -->
-

## スクリーンショット (任意)
|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img src="" width="300" /> | <img src="" width="300" /> |
